### PR TITLE
change production db uri

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -13,8 +13,9 @@ const database = {
 // select DB based on whether a test file was executed before `server.js`
 const localDb = process.env.TESTENV ? database.test : database.development
 
-// Environment variable MONGODB_URI will be available in
+// Environment variable DB_URI will be available in
+//    -- updated 2020-07-12: changed Mongo containers bc mLab discontinued
 // heroku production evironment otherwise use test or development db
-const currentDb = process.env.MONGODB_URI || localDb
+const currentDb = process.env.DB_URI || localDb
 
 module.exports = currentDb


### PR DESCRIPTION
Our MongoDB container, mLab, was acquired by Atlas (makers of MongoDB). For reasons known only to them, they decided to shut down existing all mLab services and require users to switch over to an Atlas product, then migrate. Hence, update.